### PR TITLE
fix: ユーザアイコンがnoneの時に起こるエラーを修正

### DIFF
--- a/templates/account/mypage.html
+++ b/templates/account/mypage.html
@@ -20,7 +20,7 @@
             <div class="row">
                 <div class="col-3 " style="display:inline-block;">
                     <div class="imgAspect ratio1_1">
-                        <img id="img0" src="{{ user.icon.url }}" width="100%" height="100%" alt="img" name="thumbnail_img"> 
+                        <img id="img0" src="{% if user.icon_url %}{{ user.icon_url }}{% else %}{% static 'img/placeholder.png' %}{% endif %}" width="100%" height="100%" alt="img" name="thumbnail_img"> 
                     </div>
                         <button type="button" class="btn" onclick="$('#icon').click();">変更</button>
                 </div>


### PR DESCRIPTION
ユーザアイコンがnoneの時に起こるエラー（https://stackoverflow.com/questions/15322391/django-the-image-attribute-has-no-file-associated-with-it）を修正して、noneの際はデフォルト画像を表示するようにした