### PR TITLE
北大以外のメール以外は拒否する機能

### DIFF
--- a/hokudai_furima/account/forms.py
+++ b/hokudai_furima/account/forms.py
@@ -14,9 +14,9 @@ class SignupForm(django_forms.UserCreationForm):
     def clean(self):
         cleaned_data=super().clean()
         email = cleaned_data.get("email")
-        m = re.search('@eis.hokudai.ac.jp','email')
+        m = re.search('@eis.hokudai.ac.jp$',email)
         if m is None:
-            self._errors["email"]=["登録に使えるのはhokudai.ac.jpを持つメールアドレスのみです。"]
+            self._errors["email"]=["登録に使えるのは@eis.hokudai.ac.jpを持つメールアドレスのみです。"]
 
 class LoginForm(django_forms.AuthenticationForm):
 

--- a/hokudai_furima/account/forms.py
+++ b/hokudai_furima/account/forms.py
@@ -4,12 +4,19 @@ from django import forms
 from ..account.models import User
 from django.contrib.auth import forms as django_forms, update_session_auth_hash
 from . import emails
+import re
  
 class SignupForm(django_forms.UserCreationForm):
     class Meta:
         model = User
         fields = ('username','email',)
         
+    def clean(self):
+        cleaned_data=super().clean()
+        email = cleaned_data.get("email")
+        m = re.search('@eis.hokudai.ac.jp','email')
+        if m is None:
+            self._errors["email"]=["登録に使えるのはhokudai.ac.jpを持つメールアドレスのみです。"]
 
 class LoginForm(django_forms.AuthenticationForm):
 


### PR DESCRIPTION
＠eis.hokudai.jpがメールアドレスの＠の前に入っていることはないと思い、正規表現にしてなかったのですが、"@eis.hokudai.ac.jp"@～なら可能だと言うことがわかったので2,3日のうちに、「@eis.hokudai.ac.jp」がメールアドレス末尾にくるものだけになるように修正します。