### PR TITLE
商品のsoldoutリボンが隠れる問題の修正

### DIFF
--- a/hokudai_furima/static/css/product_items.css
+++ b/hokudai_furima/static/css/product_items.css
@@ -56,6 +56,7 @@
     border-top: dashed 1px rgba(255, 255, 255, 0.65);
     border-bottom: dashed 1px rgba(255, 255, 255, 0.65);
     */
+  z-index: 1001; /* 大きい方が上になる。soldoutのリボンを上に表示するため bootstrapが1000?のため */
 }
 
 .square-box{


### PR DESCRIPTION
商品のsoldoutリボンが隠れる問題の修正
リボン部分のz-indexを1001(bootstrap4は1000)に設定した