### PR TITLE
fix: 商品タイトルが長い時にはみ出さず２行だけ表示するように修正

### DIFF
--- a/hokudai_furima/static/css/product_items.css
+++ b/hokudai_furima/static/css/product_items.css
@@ -11,8 +11,13 @@
 }
 .caption h4 {
   color: black;
-  height: 38px;
+  height: 58px;
+  font-size: 24px;
   margin: 10px 0 0 0;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 .caption p {
   color: #fe6222;


### PR DESCRIPTION
カード形式で商品を表示する際にタイトルが長いとき、無限に表示されていたので、長くても２行、２行以上なら末尾が「・・・」になるように変更