### PR TITLE
商品リストの最低カラム数を２に変更

### DIFF
--- a/templates/product/_product_list.html
+++ b/templates/product/_product_list.html
@@ -5,7 +5,7 @@
 <div class="container">
   <div class="row">
   {% for product in product_list %}
-    <div class="col-md-6 col-lg-3" style="padding:2px;">
+    <div class="col-6 col-lg-3" style="padding:2px;">
       <div class="item-wrap">
         <div class="item">
           <a href="{% url 'product:product_details' pk=product.pk %}">


### PR DESCRIPTION
商品リストの最低カラム数を１→２に変更。nemcheを参考にした。カラム数１だとなんかダサかったので。